### PR TITLE
feat: enable to set zindex

### DIFF
--- a/doc/skkeleton_indicator.jax
+++ b/doc/skkeleton_indicator.jax
@@ -163,6 +163,11 @@ col						*skkeleton-indicator-config-col*
 	(`integer`: デフォルト `1`)
 	インジケーターを表示する縦位置を、カーソル位置を基準として設定します。
 
+zindex					     *skkeleton-indicator-config-zindex*
+	(`integer`: デフォルト `nil`)
+	インジケーターを他のウィンドウに重ねる際の順序を指定します。詳しくは
+	|nvim_open_win()| の同名のオプションを参照してください。
+
 alwaysShown				*skkeleton-indicator-config-alwaysShown*
 	(`boolean`: デフォルト `true`)
 	値が true の場合、インサートモードでは常にインジケータが表示されます。

--- a/lua/skkeleton_indicator/indicator.lua
+++ b/lua/skkeleton_indicator/indicator.lua
@@ -36,6 +36,7 @@ local Modes = require "skkeleton_indicator.modes"
 ---@field border skkeleton_indicator.indicator.BorderOpt
 ---@field row integer
 ---@field col integer
+---@field zindex integer
 ---@field always_shown boolean
 ---@field fade_out_ms integer
 ---@field ignore_ft string[]
@@ -153,6 +154,7 @@ function Indicator:open()
     focusable = false,
     noautocmd = true,
     border = self:border(mode),
+    zindex = self.opts.zindex,
   })
   self:border_highlight(winid, mode)
   table.insert(self.winid, 1, winid)

--- a/lua/skkeleton_indicator/init.lua
+++ b/lua/skkeleton_indicator/init.lua
@@ -23,6 +23,7 @@ local skkeleton_indicator = {
 ---@field border skkeleton_indicator.indicator.BorderOpt
 ---@field row integer
 ---@field col integer
+---@field zindex integer
 ---@field alwaysShown boolean
 ---@field fadeOutMs integer
 ---@field ignoreFt string[]


### PR DESCRIPTION
<img width="410" alt="スクリーンショット 2023-07-08 15 10 15" src="https://github.com/delphinus/skkeleton_indicator.nvim/assets/1239245/cbf8082d-673f-497c-a945-56f421558750">

Telescope のウィンドウと被ってもちゃんと表示できるように、`zindex` オプションを追加しました。スクリーンショットでは `zindex = 9999` を指定しています。