### PR TITLE
fix: proper type of opts (argument of setup).

### DIFF
--- a/lua/skkeleton_indicator/init.lua
+++ b/lua/skkeleton_indicator/init.lua
@@ -9,27 +9,27 @@ local skkeleton_indicator = {
 }
 
 ---@class SkkeletonIndicatorOpts
----@field moduleName string
----@field eijiHlName string
----@field hiraHlName string
----@field kataHlName string
----@field hankataHlName string
----@field zenkakuHlName string
----@field eijiText string
----@field hiraText string
----@field kataText string
----@field hankataText string
----@field zenkakuText string
----@field border skkeleton_indicator.indicator.BorderOpt
----@field row integer
----@field col integer
----@field zindex integer
----@field alwaysShown boolean
----@field fadeOutMs integer
----@field ignoreFt string[]
----@field bufFilter fun(buf: integer): boolean
+---@field moduleName? string
+---@field eijiHlName? string
+---@field hiraHlName? string
+---@field kataHlName? string
+---@field hankataHlName? string
+---@field zenkakuHlName? string
+---@field eijiText? string
+---@field hiraText? string
+---@field kataText? string
+---@field hankataText? string
+---@field zenkakuText? string
+---@field border? skkeleton_indicator.indicator.BorderOpt
+---@field row? integer
+---@field col? integer
+---@field zindex? integer
+---@field alwaysShown? boolean
+---@field fadeOutMs? integer
+---@field ignoreFt? string[]
+---@field bufFilter? fun(buf: integer): boolean
 
----@param opts SkkeletonIndicatorOpts
+---@param opts? SkkeletonIndicatorOpts
 ---@return nil
 function skkeleton_indicator.setup(opts)
   local o = snake_case_dict(vim.tbl_extend("force", {


### PR DESCRIPTION
現状ですと、setupを引数無しで呼び出したり、フィールドの一部欠けたテーブルを渡すと警告が出てしまいます。
とりあえずこれで直るのですが、もっと良い方法があれば修正します。

![スクリーンショット 2024-03-08 115115](https://github.com/delphinus/skkeleton_indicator.nvim/assets/82267684/227e2d86-6cf4-4a13-bceb-c0a12238a0f5)
![スクリーンショット 2024-03-08 115133](https://github.com/delphinus/skkeleton_indicator.nvim/assets/82267684/c0f6b97d-2ca6-40fe-8536-4bb29d7233b9)
